### PR TITLE
Fix typo in variadic_func example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Defining functions with a final variadic argument
 ```bash
 variadic_func() {
 	local arg1="$1"; shift
-	local arg2="$2"; shift
+	local arg2="$1"; shift
 	local rest="$@"
 
 	# ...


### PR DESCRIPTION
After the first shift call, the second parameter is $1.
