### PR TITLE
minor - fix variadic function example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Defining functions with a final variadic argument
 ```bash
 variadic_func() {
 	local arg1="$1"; shift
-	local arg2="$2"; shift
+	local arg2="$1"; shift
 	local rest="$@"
 
 	# ...


### PR DESCRIPTION
alternatively, we could do;

```
variadic_func() {
	local arg1="$1"
	local arg2="$2"
	shift 2 ; local rest="$@"

	# ...
}
```

or some such -- but this fixes the immediate issue of skipping the 2nd argument.