### PR TITLE
Mention 'set -u' and ${arg:?message}

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ Keep in mind this is not for general shell scripting, these are rules specifical
  * Always use `local` when setting variables, unless there is reason to use `declare`
    * Exception being rare cases when you are intentionally setting a variable in an outer scope.
  * Variable names should be lowercase unless exported to environment.
- * Always use `set -eo pipefail`. Fail fast and be aware of exit codes. 
-   * Use `|| true` on programs that you intentionally let exit non-zero.
+ * Fail fast and be aware of exit codes
+   * Always use `set -uo pipefail` (fail on unset variables, and fail if any command in a pipeline fails)
+   * Consider also using `set -e` (terminate script on _any_ non-zero exit), with an ERR trap
+     * Use `|| true` on programs that you intentionally let exit non-zero.
+   * Use something like `: ${arg:?Expected argument 'arg'}` when you don't have time to do proper argument parsing
  * Never use deprecated style. Most notably:
    * Define functions as `myfunc() { ... }`, not `function myfunc { ... }`
    * Always use `[[` instead of `[` or `test`


### PR DESCRIPTION
I tried to make this as uncontentious as possible, with `set -uo pipefail` being the "do this 100% of the time by default" advice and `set -e` being the "but also consider this" choice.

The `set -u` part should not be controversial. It's `use strict` for Bash, which would be the default in _e.g._ Perl and JavaScript if not for concerns of backward compatibility.

But if you feel very, very strongly about having all three of them together (`set -euo pipefail`), I am happy to defer to your judgment there and amend this PR.

Closes #29 and #37.